### PR TITLE
changes related to app launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,5 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+/dist

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Android Smali bytecode Debugger
                 "request": "launch",
                 "name": "Smali Launch",
                 "packageName": "xxx.xxxxx",
-                "mainActivity": "xxx.xxxxx.MainActivity",
                 "deviceId": "xxxxxxx",
                 "workDir": "${workspaceFolder}"
             }
@@ -46,8 +45,7 @@ Android Smali bytecode Debugger
     }
 ```
    * the `packageName` : the apk package name
-   * the `mainActivity` : the apk entry class
-   * the `deviceId` : your device id which getted from the `adb devices` command
+   * the `deviceId` : your device id obtained from the `adb devices` command
 
 ## TO DO
  - implement the evaluate function totally

--- a/src/AdbClient.ts
+++ b/src/AdbClient.ts
@@ -117,11 +117,11 @@ export class AdbClient
         return processId;
     }
 
-    public static async launchApp(packageName : string, mainActivity : string) : Promise<string>
+    public static async launchApp(packageName : string) : Promise<string>
     {
         const adb : LocalCommand = {
             command : "adb",
-            args : ['-s', AdbClient.device_sid, 'shell', 'am', 'start', '-D', '-n', packageName + '/' + mainActivity]
+            args : ['-s', AdbClient.device_sid, 'shell', 'monkey', '-p', packageName, '1']
         };
 
         const { stdout } =  await runCommand(adb);

--- a/src/AdbClient.ts
+++ b/src/AdbClient.ts
@@ -119,12 +119,17 @@ export class AdbClient
 
     public static async launchApp(packageName : string) : Promise<string>
     {
-        const adb : LocalCommand = {
+        const stopAppCmd : LocalCommand = {
+            command : "adb",
+            args : ['-s', AdbClient.device_sid, 'shell', 'am', 'force-stop', packageName]
+        };
+        const launchAppCmd : LocalCommand = {
             command : "adb",
             args : ['-s', AdbClient.device_sid, 'shell', 'monkey', '-p', packageName, '1']
         };
 
-        const { stdout } =  await runCommand(adb);
+        await runCommand(stopAppCmd);
+        await runCommand(launchAppCmd);
         return this.getProcessIdByName(packageName);
     }
 

--- a/src/SmaliDebug.ts
+++ b/src/SmaliDebug.ts
@@ -300,16 +300,6 @@ export class ASDebugSession extends LoggingDebugSession
 			return;
 		}
 
-		if (!args.mainActivity)
-		{
-			this.sendErrorResponse(
-				response,
-				2000,
-				'Failed to continue: The mainActivity attribute is missing in the debug configuration in launch.json'
-			);
-			return;
-		}
-
 		if (!args.deviceId)
 		{
 			this.sendErrorResponse(
@@ -345,7 +335,7 @@ export class ASDebugSession extends LoggingDebugSession
 		let pid : string = await AdbClient.getProcessIdByName(args.packageName);
 		if ("" == pid)
 		{
-			pid = await AdbClient.launchApp(args.packageName, args.mainActivity);
+			pid = await AdbClient.launchApp(args.packageName);
 			if ("" == pid) {
 				this.sendErrorResponse(
 					response,

--- a/src/interfaces_classes.ts
+++ b/src/interfaces_classes.ts
@@ -8,7 +8,6 @@ import { getClassStatus, logError } from "./utils";
 export interface SmaliLaunchArguments
 {
     packageName? : string;
-    mainActivity? : string;
     deviceId? : string;
     workDir? : string;
     trace? : 'verbose' | 'trace' | 'info' | 'log' | 'warn' | 'error';


### PR DESCRIPTION
Changelog:

- Don't require `MainActivity` in `launch.json` 
	(uses `adb shell monkey -p {packageName} 1` command instead) [more info](https://stackoverflow.com/questions/4567904/how-to-start-an-application-using-android-adb-tools)
- Force stop app before launching it (fixes issue when app can't be launched/re-launched)
- gitignore `dist` dir